### PR TITLE
feat: Updated nitpick styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # .nitpick
 Shared python linters' and static type checking tools' settings used by NextGenContribution's projects
+
+## Usage
+For each project, you can use the following configuration (`.nitpick.toml`) to use the shared settings. They're all optional and can be included/excluded as needed.
+
+```toml
+[tool.nitpick]
+style = [
+    "github://NextGenContributions/.nitpick@main/nitpick_styles/django-flake8.toml",
+    "github://NextGenContributions/.nitpick@main/nitpick_styles/django-mypy.toml",
+    "github://NextGenContributions/.nitpick@main/nitpick_styles/django-ruff.toml",
+    "github://NextGenContributions/.nitpick@main/nitpick_styles/django-pyproject.toml",
+    "github://NextGenContributions/.nitpick@main/nitpick_styles/generic-codacy.toml",
+    "github://NextGenContributions/.nitpick@main/nitpick_styles/generic-deepsource.toml",
+    "github://NextGenContributions/.nitpick@main/nitpick_styles/generic-mypy.toml",
+    "github://NextGenContributions/.nitpick@main/nitpick_styles/generic-flake8.toml",
+    "github://NextGenContributions/.nitpick@main/nitpick_styles/generic-pre-commit-hooks.toml",
+    "github://NextGenContributions/.nitpick@main/nitpick_styles/generic-pylintrc.toml",
+    "github://NextGenContributions/.nitpick@main/nitpick_styles/generic-pyproject.toml",
+    "github://NextGenContributions/.nitpick@main/nitpick_styles/generic-ruff.toml",
+    "github://NextGenContributions/.nitpick@main/nitpick_styles/generic-taplo.toml",
+    "github://NextGenContributions/.nitpick@main/nitpick_styles/generic-trunk.toml",
+]
+# We don't really care about caching as it should be rather quick to fetch anyway, this ensures fresh configs
+cache = "never"
+```
+
+Typically, a Django project should include all the generic styles as well as the django specific ones. A generic project should include only the generic styles.
+
+
+## Pre-commit hooks
+
+You can include `generic-pre-commit-hooks.toml` to apply pre-commit hooks to your repo. This would help running `nitpick` check and fix before each commit. However, since `pre-commit` would only install the latest non-moving rev, to get the latest styling config from this repo. Run the following command after `pre-commit install`:
+
+```bash
+pre-commit autoupdate --bleeding-edge --repo "https://github.com/NextGenContributions/nitpick"
+```
+
+## Important notes
+
+Since `nitpick` is not very well maintained and despite our efforts, there are still plenty of issues with it. It's recommended to go through the list of issues here https://github.com/NextGenContributions/nitpick/issues and workaround them as needed while modifying the configs in your project to avoid surprises.

--- a/nitpick_styles/django-flake8.toml
+++ b/nitpick_styles/django-flake8.toml
@@ -1,14 +1,12 @@
 [nitpick.meta]
-name = "Flake8"
+name = "Django Flake8"
 url = "https://github.com/PyCQA/flake8"
 
 [nitpick.files.present]
-"setup.cfg" = "Create the file with the contents below"
+".flake8" = "Create the file with the contents below"
 
-# TODO(phuongfi91): We prefer .flake8 file over setup.cfg for flake8
-#[nitpick.files.".flake8"]
-[nitpick.files."setup.cfg"]
-comma_separated_values = [
+[nitpick.files.comma_separated_values]
+".flake8" = [
     "flake8.ignore",
     "flake8.extend-ignore",
     "flake8.exclude",
@@ -17,18 +15,17 @@ comma_separated_values = [
 
 
 
-["setup.cfg".flake8.per-file-ignores]
-# TODO(phuongfi91): Fix issue with multiline config value or validate that ConfigParser can work with array []
-# **/settings/*.py: Allow `__init__.py` with logic for configuration:
-# **/migrations/*.py: Allow to have magic numbers inside migrations and wrong module names:
-per-file-ignores = """
-\n\
-**/settings/*.py:
+[".flake8".flake8.per-file-ignores]
+# Allow `__init__.py` with logic for configuration:
+"**/settings/*.py" = """\
     WPS226,\
     WPS407,\
     WPS412,\
-    WPS432\n\
-**/migrations/*.py:
+    WPS432\
+"""
+# Allow to have magic numbers inside migrations and wrong module names:
+"**/migrations/*.py" = """\
     WPS102,\
     WPS114,\
-    WPS432"""
+    WPS432\
+"""

--- a/nitpick_styles/django-mypy.toml
+++ b/nitpick_styles/django-mypy.toml
@@ -110,12 +110,6 @@ exclude = """\
 """
 
 
-## TODO(phuongfi91): This config section nested name is not supported by nitpick ini plugin
-#[".mypy.ini".mypy.plugins.django-stubs]
-## TODO(jhassine): Maybe remove this and let it read from DJANGO_SETTINGS_MODULE env var
-#django_settings_module = "config.settings.dev"
-
-
 [".mypy.ini".pydantic-mypy]
 # https://docs.pydantic.dev/latest/integrations/mypy/#configuring-the-plugin
 init_forbid_extra = true
@@ -126,5 +120,5 @@ warn_required_dynamic_aliases = true
 # ------------------
 # You can change some checks per module using this syntax
 # Ref: https://mypy.readthedocs.io/en/latest/config_file.html#example-mypy-ini
-#[".mypy.ini".mypy-mycode.foo."*"]
+#[".mypy.ini"."mypy-mycode.foo.*"]
 # Your custom options here

--- a/nitpick_styles/django-mypy.toml
+++ b/nitpick_styles/django-mypy.toml
@@ -1,0 +1,130 @@
+[nitpick.meta]
+name = "Django mypy"
+url = "https://mypy.readthedocs.io/en/stable/config_file.html"
+
+[nitpick.files.present]
+".mypy.ini" = "Create the file with the contents below"
+
+
+[nitpick.files.comma_separated_values]
+".mypy.ini" = [
+    "mypy.enable_error_code",
+    "mypy.disable_error_code",
+    "mypy.plugins",
+    "mypy.files",
+    "mypy.exclude",
+]
+
+
+
+[".mypy.ini".mypy]
+# https://mypy.readthedocs.io/en/stable/config_file.html#confval-mypy_path
+mypy_path = "./out"
+
+# Configuring error messages:
+show_error_codes = true
+show_column_numbers = true
+
+# Configuring strictness:
+strict = true
+# Strict mode; enables the following flags:
+# --warn-unused-configs,
+# --disallow-any-generics,
+# --disallow-subclassing-any,
+# --disallow-untyped-calls,
+# --disallow-untyped-defs,
+# --disallow-incomplete-defs,
+# --check-untyped-defs,
+# --disallow-untyped-decorators,
+# --warn-redundant-casts,
+# --warn-unused-ignores,
+# --warn-return-any,
+# --no-implicit-reexport,
+# --strict-equality,
+# --extra-checks
+
+warn_unreachable = true
+disallow_any_unimported = true
+disallow_any_expr = false
+disallow_any_explicit = false
+
+
+# warn_unused_configs = true
+# warn_return_any = true
+# check_untyped_defs = true
+explicit_package_bases = true
+# warn_redundant_casts = true
+# disallow_any_generics = true
+# no_implicit_reexport = true
+# Require ignore comments to include error codes
+# https://docs.astral.sh/ruff/rules/blanket-type-ignore/#blanket-type-ignore-pgh003
+# https://mypy.readthedocs.io/en/stable/error_code_list2.html#check-that-type-ignore-include-an-error-code-ignore-without-code
+enable_error_code = """\
+    ignore-without-code,\
+    truthy-bool,\
+    redundant-self,\
+    redundant-expr,\
+    possibly-undefined,\
+    truthy-iterable,\
+    unused-awaitable,\
+    unused-ignore,\
+    explicit-override,\
+    mutable-override,\
+    unimported-reveal,\
+    narrowed-type-not-subtype\
+"""
+
+follow_imports_for_stubs = true
+
+# https://mypy.readthedocs.io/en/latest/error_code_list2.html#code-no-untyped-def
+# Disabling here in Mypy as Ruff is already handling this
+# https://docs.astral.sh/ruff/rules/missing-return-type-undocumented-public-function/
+# Ruff has the following benefits:
+# - Sometimes a fix available.
+# - Is having instant on type checking whereas Mypy is slow to notice the fix.
+# - Mypy is too verbose making the whole function red underlined and it's hard to see the actual code anymore.
+# - Furthermore we have the infer tools available which can help figuring out the right return type.
+disallow_untyped_defs = false
+
+# * no-untyped-def: mypy doesn't understand nested dict items' type, only recognizes them as object dict-item,
+# Ruff is already handling this as explained for "disallow_untyped_defs" section above ^
+disable_error_code = """\
+    no-untyped-def\
+"""
+
+plugins = """\
+    mypy_django_plugin.main,\
+    pydantic.mypy,\
+    mypy_drf_plugin.main\
+"""
+
+files = """\
+    .\
+"""
+
+#exclude = (out|typings)/
+
+# Exclude .pyi files:
+exclude = """\
+    .*\\.pyi\
+"""
+
+
+## TODO(phuongfi91): This config section nested name is not supported by nitpick ini plugin
+#[".mypy.ini".mypy.plugins.django-stubs]
+## TODO(jhassine): Maybe remove this and let it read from DJANGO_SETTINGS_MODULE env var
+#django_settings_module = "config.settings.dev"
+
+
+[".mypy.ini".pydantic-mypy]
+# https://docs.pydantic.dev/latest/integrations/mypy/#configuring-the-plugin
+init_forbid_extra = true
+init_typed = true
+warn_required_dynamic_aliases = true
+
+# Per-module options
+# ------------------
+# You can change some checks per module using this syntax
+# Ref: https://mypy.readthedocs.io/en/latest/config_file.html#example-mypy-ini
+#[".mypy.ini".mypy-mycode.foo."*"]
+# Your custom options here

--- a/nitpick_styles/django-pyproject.toml
+++ b/nitpick_styles/django-pyproject.toml
@@ -1,0 +1,22 @@
+[nitpick.meta]
+name = "Django project configs"
+url = "https://packaging.python.org/en/latest/specifications/pyproject-toml/"
+
+
+[nitpick.files.present]
+"pyproject.toml" = "Create the file with the contents below"
+
+
+# Dependency Groups
+["pyproject.toml".dependency-groups]
+dev = [
+    # typing
+    "django-stubs-ext>=5.1.1",
+    "django-stubs[compatible-mypy]>=5.1.1",
+
+    # linter & fomatter
+    "pylint-django>=2.6.1",
+
+    # test
+    "pytest-django>=4.9.0",
+]

--- a/nitpick_styles/django-ruff.toml
+++ b/nitpick_styles/django-ruff.toml
@@ -1,5 +1,5 @@
 [nitpick.meta]
-name = "ruff"
+name = "Django ruff"
 url = "https://github.com/astral-sh/ruff"
 
 [nitpick.files.present]

--- a/nitpick_styles/generic-codacy.toml
+++ b/nitpick_styles/generic-codacy.toml
@@ -1,0 +1,77 @@
+[nitpick.meta]
+name = "codacy"
+url = "https://docs.codacy.com/repositories-configure/codacy-configuration-file/"
+
+[nitpick.files.present]
+".codacy.yaml" = "Create the file with the contents below"
+
+
+
+# TODO(phuongfi91): Does 'codacy' works without this "---" line? Nitpick does not support adding this
+# ---
+
+# Python security analyzer
+[".codacy.yaml".engines.bandit]
+enabled = true
+
+# Docker linter
+[".codacy.yaml".engines.hadolint]
+enabled = true
+
+# Python static analysis tool
+[".codacy.yaml".engines.prospector]
+enabled = true
+
+# Python linter
+[".codacy.yaml".engines.pylintpython3]
+enabled = true
+
+# JSON linter
+[".codacy.yaml".engines.jacksonlinter]
+enabled = true
+
+# Markdown linter
+[".codacy.yaml".engines.markdownlint]
+enabled = true
+
+# Generic static analysis tool
+[".codacy.yaml".engines.semgrep]
+enabled = true
+
+# Shell script linter
+[".codacy.yaml".engines.shellcheck]
+enabled = true
+
+# JSON/YAML linter
+[".codacy.yaml".engines.spectral]
+enabled = true
+
+# Duplicated code detection
+[".codacy.yaml".engines.duplication]
+minTokenMatch = 50
+skipLexicalErrors = true
+ignoreLiterals = true
+ignoreIdentifiers = true
+ignoreAnnotations = true
+ignoreUsings = true
+exclude_paths = [
+    "test_*.py",
+    "tests/**"
+]
+
+[".codacy.yaml"]
+exclude_paths = [
+    "*.egg",
+    "*.egg-info/**",
+    ".eggs/**",
+    ".git/**",
+    ".tox/**",
+    ".venv/**",
+    "__pycache__/**",
+    "bin/**",
+    "build/**",
+    "dist/**",
+    # Test files
+    "test_*.py",
+    "tests/**"
+]

--- a/nitpick_styles/generic-deepsource.toml
+++ b/nitpick_styles/generic-deepsource.toml
@@ -25,7 +25,7 @@ test_patterns = [
 ]
 version = 1
 
-[".deepsource.toml"."[analyzers]"]
+[[".deepsource.toml".analyzers]]
 enabled = true
 name = "python"
 
@@ -36,6 +36,6 @@ runtime_version = "3.x.x"
 skip_doc_coverage = ["init", "magic", "module"]
 type_checker = "mypy"
 
-[".deepsource.toml"."[transformers]"]
+[[".deepsource.toml".transformers]]
 enabled = true
 name = "ruff"

--- a/nitpick_styles/generic-deepsource.toml
+++ b/nitpick_styles/generic-deepsource.toml
@@ -1,0 +1,41 @@
+[nitpick.meta]
+name = "Deepsource"
+url = "https://docs.deepsource.com/docs/configuration"
+
+[nitpick.files.present]
+".deepsource.toml" = "Create the file with the contents below"
+
+
+[".deepsource.toml"]
+exclude_patterns = [
+  "*.egg",
+  "*.egg-info/**",
+  ".eggs/**",
+  ".git/**",
+  ".tox/**",
+  ".venv/**",
+  "__pycache__/**",
+  "bin/**",
+  "build/**",
+  "dist/**",
+]
+test_patterns = [
+  "test_*.py",
+  "tests/**",
+]
+version = 1
+
+[".deepsource.toml"."[analyzers]"]
+enabled = true
+name = "python"
+
+[".deepsource.toml".analyzers.meta]
+cyclomatic_complexity_threshold = "medium"
+max_line_length = 120 # should match this repo's config in e.g. pyproject.toml
+runtime_version = "3.x.x"
+skip_doc_coverage = ["init", "magic", "module"]
+type_checker = "mypy"
+
+[".deepsource.toml"."[transformers]"]
+enabled = true
+name = "ruff"

--- a/nitpick_styles/generic-deepsource.toml
+++ b/nitpick_styles/generic-deepsource.toml
@@ -31,7 +31,7 @@ name = "python"
 
 [".deepsource.toml".analyzers.meta]
 cyclomatic_complexity_threshold = "medium"
-max_line_length = 120 # should match this repo's config in e.g. pyproject.toml
+max_line_length = 88 # should match this repo's config in e.g. pyproject.toml
 runtime_version = "3.x.x"
 skip_doc_coverage = ["init", "magic", "module"]
 type_checker = "mypy"

--- a/nitpick_styles/generic-flake8.toml
+++ b/nitpick_styles/generic-flake8.toml
@@ -3,18 +3,15 @@ name = "Flake8"
 url = "https://github.com/PyCQA/flake8"
 
 [nitpick.files.present]
-"setup.cfg" = "Create the file with the contents below"
+".flake8" = "Create the file with the contents below"
 
-# TODO(phuongfi91): We prefer .flake8 file over setup.cfg for flake8
-#[nitpick.files.".flake8"]
-[nitpick.files."setup.cfg"]
-comma_separated_values = [
+[nitpick.files.comma_separated_values]
+".flake8" = [
     "flake8.ignore",
     "flake8.extend-ignore",
     "flake8.exclude",
     "flake8.per-file-ignores",
 ]
-
 
 
 # We use flake8 linter to get some opionated linting rules from Wemake Python Styleguide:
@@ -34,8 +31,7 @@ comma_separated_values = [
 #
 # Wemake Python Styleguide vs Ruff story:
 # https://github.com/astral-sh/ruff/issues/8022
-
-["setup.cfg".flake8]
+[".flake8".flake8]
 format = "wemake"
 show-source = true
 statistics = false
@@ -52,12 +48,13 @@ max-complexity = 6
 # noqa-include-name = true
 
 # Excluding some directories:
-exclude = """
-.git,\
-__pycache__,\
-.venv,\
-.eggs,\
-*.egg"""
+exclude = """\
+    .git,\
+    __pycache__,\
+    .venv,\
+    .eggs,\
+    *.egg\
+"""
 
 
 
@@ -68,13 +65,14 @@ __pycache__,\
 # D401: Checks for docstring first lines that are not in an imperative mood.
 # X100: ???
 # W504: Line break occurred after a binary operator
-ignore = """
-D100,\
-D104,\
-D106,\
-D401,\
-X100,\
-W504"""
+ignore = """\
+    D100,\
+    D104,\
+    D106,\
+    D401,\
+    X100,\
+    W504\
+"""
 
 
 # *** DISABLING FLAKE8 RULES THAT RUFF ALREADY COVERS: ***
@@ -127,56 +125,23 @@ inline-quotes = "double"
 # WPS324: Enforce consistent return statements.
 #   https://wemake-python-styleguide.readthedocs.io/en/latest/pages/usage/violations/consistency.html#wemake_python_styleguide.violations.consistency.InconsistentReturnViolation
 #   This is a good rule in general but seem to conflict with some other linters (e.g. SonarLint) in some cases
-extend-ignore = """
-WPS110,\
-WPS111,\
-WPS114,\
-WPS332,\
-WPS410,\
-WPS602,\
-WPS300,\
-WPS426,\
-W503,\
-W504,\
-WPS122,\
-WPS412,\
-WPS102,\
-WPS324"""
+extend-ignore = """\
+    WPS110,\
+    WPS111,\
+    WPS114,\
+    WPS332,\
+    WPS410,\
+    WPS602,\
+    WPS300,\
+    WPS426,\
+    W503,\
+    W504,\
+    WPS122,\
+    WPS412,\
+    WPS102,\
+    WPS324\
+"""
 
-
-# *** PER-FILE-IGNORES: ***
-# Docs: https://github.com/snoack/flake8-per-file-ignores
-# You can completely or partially disable our custom checks,
-# to do so you have to ignore `WPS` letters for all python files:
-
-# WPS116: Found consecutive underscores name
-#   https://wemake-python-styleguide.readthedocs.io/en/latest/pages/usage/violations/naming.html#wemake_python_styleguide.violations.naming.ConsecutiveUnderscoresInNameViolation
-#   As a general rule this is bad habit but in gherkin step implementation it's ok? to have this kind of naming :D
-# WPS118: Found too long name
-# WPS218: Found too many `assert` statements
-#   https://wemake-python-styleguide.readthedocs.io/en/latest/pages/usage/violations/complexity.html#wemake_python_styleguide.violations.complexity.TooManyAssertsViolation
-#   Well, tests are about asserts, everywhere else they are bad and should not be relied on prod optimized pythons
-# WPS432: Enable magic numbers for tests
-per-file-ignores = """
-tests/*.py:\
-    WPS116,\
-    WPS118,\
-    WPS218,\
-    WPS432"""
-
-# TODO(phuongfi91): Fix issue with multiline config value or validate that ConfigParser can work with array []
-#per-file-ignores = """
-#\n\
-#tests/*.py:\
-#    WPS116,\
-#    WPS118,\
-#    WPS218,\
-#    WPS432\n\
-#tests_path_2/*.py:\
-#    WPS116,\
-#    WPS118,\
-#    WPS218,\
-#    WPS432"""
 
 
 # *** WPS COMPLEXITY RULES RELAXATION: ***
@@ -203,3 +168,26 @@ max-raises = 5
 # 'sonarlint' has this rule set as 4 so we can follow that for the sake of consistency:
 max-string-usages = 4
 max-try-body-length = 9
+
+
+
+# *** PER-FILE-IGNORES: ***
+# Docs: https://github.com/snoack/flake8-per-file-ignores
+# You can completely or partially disable our custom checks,
+# to do so you have to ignore `WPS` letters for all python files:
+
+[".flake8".flake8.per-file-ignores]
+# WPS116: Found consecutive underscores name
+#   https://wemake-python-styleguide.readthedocs.io/en/latest/pages/usage/violations/naming.html#wemake_python_styleguide.violations.naming.ConsecutiveUnderscoresInNameViolation
+#   As a general rule this is bad habit but in gherkin step implementation it's ok? to have this kind of naming :D
+# WPS118: Found too long name
+# WPS218: Found too many `assert` statements
+#   https://wemake-python-styleguide.readthedocs.io/en/latest/pages/usage/violations/complexity.html#wemake_python_styleguide.violations.complexity.TooManyAssertsViolation
+#   Well, tests are about asserts, everywhere else they are bad and should not be relied on prod optimized pythons
+# WPS432: Enable magic numbers for tests
+"tests/*.py" = """\
+    WPS116,\
+    WPS118,\
+    WPS218,\
+    WPS432\
+"""

--- a/nitpick_styles/generic-mypy.toml
+++ b/nitpick_styles/generic-mypy.toml
@@ -42,15 +42,4 @@ enable_error_code = """\
     narrowed-type-not-subtype\
 """
 
-plugins = """\
-    mypy_django_plugin.main,\
-    pydantic.mypy\
-"""
-
 enable_incomplete_feature = "NewGenericSyntax"
-
-
-
-## TODO(phuongfi91): This config section nested name is not supported by nitpick ini plugin
-#[".mypy.ini".mypy.plugins.django-stubs]
-#django_settings_module = "tests.settings"

--- a/nitpick_styles/generic-mypy.toml
+++ b/nitpick_styles/generic-mypy.toml
@@ -1,0 +1,56 @@
+[nitpick.meta]
+name = "mypy"
+url = "https://mypy.readthedocs.io/en/stable/config_file.html"
+
+[nitpick.files.present]
+".mypy.ini" = "Create the file with the contents below"
+
+
+[nitpick.files.comma_separated_values]
+".mypy.ini" = [
+    "mypy.enable_error_code",
+    "mypy.disable_error_code",
+    "mypy.plugins",
+    "mypy.files",
+    "mypy.exclude",
+]
+
+
+
+[".mypy.ini".mypy]
+strict = true
+warn_unreachable = true
+
+# Not sure if needed:
+check_untyped_defs = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+warn_unused_configs = true
+
+enable_error_code = """\
+    ignore-without-code,\
+    truthy-bool,\
+    redundant-self,\
+    redundant-expr,\
+    possibly-undefined,\
+    truthy-iterable,\
+    unused-awaitable,\
+    unused-ignore,\
+    explicit-override,\
+    mutable-override,\
+    unimported-reveal,\
+    narrowed-type-not-subtype\
+"""
+
+plugins = """\
+    mypy_django_plugin.main,\
+    pydantic.mypy\
+"""
+
+enable_incomplete_feature = "NewGenericSyntax"
+
+
+
+## TODO(phuongfi91): This config section nested name is not supported by nitpick ini plugin
+#[".mypy.ini".mypy.plugins.django-stubs]
+#django_settings_module = "tests.settings"

--- a/nitpick_styles/generic-pre-commit-hooks.toml
+++ b/nitpick_styles/generic-pre-commit-hooks.toml
@@ -15,7 +15,6 @@ default_stages = ["pre-commit"]
 # nitpick pre-commit hook
 [[".pre-commit-config.yaml".repos]]
 repo = "https://github.com/NextGenContributions/nitpick"
-rev = "v0.35.0"
 [[".pre-commit-config.yaml".repos.hooks]]
 id = "nitpick-check"
 [[".pre-commit-config.yaml".repos.hooks]]

--- a/nitpick_styles/generic-pyproject.toml
+++ b/nitpick_styles/generic-pyproject.toml
@@ -19,10 +19,10 @@ allow_zero_version = true
 no_git_verify = false
 tag_format = "v{version}"
 version_toml = ["pyproject.toml:project.version"]
-# TODO(phuongfi91): Find a pattern that doesn't rely on the project name.
+# TODO(phuongfi91): Utilize project-config util to put a constraint on this
 #version_variables = [
-#    "django2pydantic/__init__.py:__version__",
-#    "uv.lock:\"django2pydantic\"\\nversion",
+#    "project_name/__init__.py:__version__",
+#    "uv.lock:\"project_name\"\\nversion",
 #]
 
 ["pyproject.toml".tool.semantic_release.branches.main]
@@ -104,8 +104,6 @@ dev = [
     # typing
     "basedpyright>=1.21.0",
     "beartype>=0.19.0",
-    "django-stubs-ext>=5.1.1",
-    "django-stubs[compatible-mypy]>=5.1.1",
     "mypy>=1.13.0",
     "pyre-check>=0.9.23",
     "pyright>=1.1.388",
@@ -115,7 +113,6 @@ dev = [
     # linter & fomatter
     "import-linter>=2.1",
     "isort>=5.13.2",
-    "pylint-django>=2.6.1",
     "ruff>=0.7.3",
     "semgrep>=1.85.0",
     "wemake-python-styleguide>=1.0.0",
@@ -132,7 +129,6 @@ dev = [
     # test
     "hypothesis>=6.118.0",
     "pytest-cov>=6.0.0",
-    "pytest-django>=4.9.0",
     "pytest-instafail>=0.5.0",
     "pytest-testmon>=2.1.1",
     "pytest-watch>=4.2.0",

--- a/nitpick_styles/generic-ruff.toml
+++ b/nitpick_styles/generic-ruff.toml
@@ -55,6 +55,7 @@ indent-width = 4
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
 select = ["ALL"]
+external = ["WPS", "C", "W"]
 ignore = [
   # Enforce removal of unused 'noqa' rule.
   # https://docs.astral.sh/ruff/linter/?query=RUF100#disabling-fixes
@@ -80,7 +81,7 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 [".ruff.toml".lint.per-file-ignores]
 # Ignore assert usage in tests
-"tests/*.py" = ["S101"]
+"tests/**/test_*.py" = ["S101"]
 
 
 [".ruff.toml".lint.pydocstyle]

--- a/nitpick_styles/generic-trunk.toml
+++ b/nitpick_styles/generic-trunk.toml
@@ -1,0 +1,127 @@
+[nitpick.meta]
+name = "Trunk"
+url = "https://docs.trunk.io/cli/configuration#config-format"
+
+[nitpick.files.present]
+".trunk/trunk.yaml" = "Create the file with the contents below"
+".trunk/.gitignore" = "Create the file with the contents below"
+".trunk/configs/.markdownlint.yaml" = "Create the file with the contents below"
+".trunk/configs/.shellcheckrc" = "Create the file with the contents below"
+".trunk/configs/.yamllint.yaml" = "Create the file with the contents below"
+
+
+[nitpick.files.tags]
+".trunk/configs/.shellcheckrc" = ["text"]
+
+# ************************ ".trunk/trunk.yaml" ************************
+[".trunk/trunk.yaml"]
+# This file controls the behavior of Trunk: https://docs.trunk.io/cli
+# To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
+version = "0.1"
+
+[".trunk/trunk.yaml".cli]
+version = "1.22.9"
+
+# Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
+[[".trunk/trunk.yaml".plugins.sources]]
+id = "trunk"
+ref = "v1.6.7"
+uri = "https://github.com/trunk-io/plugins"
+
+# Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
+[".trunk/trunk.yaml".runtimes]
+enabled = [
+    "python@>=3.10.8",
+]
+
+# This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
+[".trunk/trunk.yaml".lint]
+enabled = [
+    "actionlint@1.7.7",
+    "bandit@1.8.2",
+    "git-diff-check",
+    "markdownlint@0.44.0",
+    "mypy@1.14.1",
+    "osv-scanner@1.9.2",
+    "prettier@3.4.2",
+    "pylint@3.3.4",
+    "renovate@39.141.0",
+    "ruff@0.9.3",
+    "shellcheck@0.10.0",
+    "shfmt@3.6.0",
+    "taplo@0.9.3",
+    "trufflehog@3.88.3",
+    "yamllint@1.35.1"
+]
+
+[[".trunk/trunk.yaml".lint.ignore]]
+linters = ["ALL"]
+paths = [
+    "*.egg",
+    "*.egg-info/**",
+    ".eggs/**",
+    ".git/**",
+    ".tox/**",
+    ".venv/**",
+    "__pycache__/**",
+    "bin/**",
+    "build/**",
+    "dist/**",
+    # Test files
+    "test_*.py",
+    "tests/**"
+]
+
+
+
+# ************************ ".trunk/.gitignore ************************
+[[".trunk/.gitignore".contains]]
+line = "*out"
+[[".trunk/.gitignore".contains]]
+line = "*logs"
+[[".trunk/.gitignore".contains]]
+line = "*actions"
+[[".trunk/.gitignore".contains]]
+line = "*notifications"
+[[".trunk/.gitignore".contains]]
+line = "*tools"
+[[".trunk/.gitignore".contains]]
+line = "plugins"
+[[".trunk/.gitignore".contains]]
+line = "user_trunk.yaml"
+[[".trunk/.gitignore".contains]]
+line = "user.yaml"
+[[".trunk/.gitignore".contains]]
+line = "tmp"
+
+
+
+# ************************ ".trunk/configs/.markdownlint.yaml" ************************
+[".trunk/configs/.markdownlint.yaml"]
+# Prettier friendly markdownlint config (all formatting rules disabled)
+extends = "markdownlint/style/prettier"
+
+
+
+# ************************ ".trunk/configs/.shellcheckrc" ************************
+[[".trunk/configs/.shellcheckrc".contains]]
+line = "enable=all"
+[[".trunk/configs/.shellcheckrc".contains]]
+line = "source-path=SCRIPTDIR"
+[[".trunk/configs/.shellcheckrc".contains]]
+line = "disable=SC2154"
+# If you're having issues with shellcheck following source, disable the errors via:
+# disable=SC1090
+# disable=SC1091
+
+
+
+# ************************ ".trunk/configs/.yamllint.yaml" ************************
+[".trunk/configs/.yamllint.yaml".rules.quoted-strings]
+required = "only-when-needed"
+extra-allowed = ["{|}"]
+
+[".trunk/configs/.yamllint.yaml".rules.octal-values]
+forbid-implicit-octal = true
+
+#[".trunk/configs/.yamllint.yaml".rules.key-duplicates]


### PR DESCRIPTION
Fix #1 

- Updated flake8 config to reflect recent fixes to nitpick
- Added mypy, codacy, deepsource, trunk configs
  - Some configs have weird quirks that may not be supported by nitpick, can be ok for now and fixed later
- Updated `README.md`

## Summary by Sourcery

Build:
- Add MyPy, Codacy, and Deepsource configuration files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new configuration integrations for enhanced static analysis and type checking, including setups tailored for Django projects and support for multiple analysis engines.
  - Added new configuration files for Codacy, DeepSource, and Trunk, enhancing code analysis and linting capabilities.
  - Introduced a new configuration file for MyPy and updated existing configurations for Flake8 and Ruff to improve linting and type checking.
  
- **Chores**
  - Refined and reorganized existing linting configurations to improve naming consistency, file referencing, and overall readability without altering established rules.
  - Updated pre-commit hooks configuration to include new repositories and hooks for improved code quality checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->