### PR TITLE
Update generic-flake8.toml

### DIFF
--- a/nitpick_styles/generic-flake8.toml
+++ b/nitpick_styles/generic-flake8.toml
@@ -66,6 +66,7 @@ exclude = """\
 # X100: ???
 # W504: Line break occurred after a binary operator
 # E501: Line too long. Should be handled by ruff
+# E704: multiple statements on one line (def). When using ellipsis (...) with methods, Ruff formats them single line and then this rule triggers. 
 ignore = """\
     D100,\
     D104,\
@@ -73,7 +74,8 @@ ignore = """\
     D401,\
     X100,\
     W504,\
-    E501\
+    E501,\
+    E704\
 """
 
 


### PR DESCRIPTION
Disabling this rule as when using ellipsis `...` with method defs which seems fine with other linters/type checkers, ruff formats this single line and this rule complains.

![image](https://github.com/user-attachments/assets/6556a814-a91f-447b-8ee3-6ef41ed554ac)

![image](https://github.com/user-attachments/assets/8c777028-4c56-4305-8566-b6710053d303)

## Summary by Sourcery

Chores:
- Add an exception for E704 rule in Flake8 configuration to handle multiple statements on one line, particularly for methods using ellipsis