### PR TITLE
feat: Support coveragepy .coveragerc config

### DIFF
--- a/nitpick_styles/generic-coveragerc.toml
+++ b/nitpick_styles/generic-coveragerc.toml
@@ -1,0 +1,28 @@
+[nitpick.meta]
+name = "Coverage.py"
+url = "https://github.com/nedbat/coveragepy"
+
+[nitpick.files.present]
+".coveragerc" = "Create the file with the contents below"
+
+[".coveragerc".report]
+exclude_also = """
+    pragma: no cover
+    def __repr__
+    def __str__
+    if self.debug:
+    if settings.DEBUG
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if __name__ == .__main__.:
+    if TYPE_CHECKING:
+    if typing.TYPE_CHECKING:
+    class .*\\bProtocol\\):
+    @(abc\\.)?abstractmethod
+    @(pytest\\.|pytest\\.mark.\\.)?skip
+    @(pytest\\.|pytest\\.mark.\\.)?xfail
+"""
+
+[".coveragerc".run]
+relative_files = true


### PR DESCRIPTION
## Summary by Sourcery

Add a generic Coverage.py configuration style for Nitpick

New Features:
- Add a standard .coveragerc configuration template for Coverage.py

Documentation:
- Provide a default configuration for excluding common code from coverage reports 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request adds a standard .coveragerc configuration template for Coverage.py, enhancing the usability of the Nitpick tool by providing a default configuration that excludes common code from coverage reports. These changes aim to streamline the coverage reporting process and improve code quality checks.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a configuration file to customize code coverage reporting, improving how coverage is measured and reported by excluding common boilerplate and testing-related code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->